### PR TITLE
Added test No. 490 to Wikidata.owl

### DIFF
--- a/internal/wikidata.owl
+++ b/internal/wikidata.owl
@@ -12,6 +12,13 @@
     <owl:Ontology rdf:about="http://enanomapper.github.io/ontologies/internal/wikidata.owl">
         <dc:contributor>Egon Willighagen</dc:contributor>
     </owl:Ontology>
+
+    <!-- http://www.wikidata.org/entity/Q103983010 -->
+
+    <owl:Class rdf:about="http://www.wikidata.org/entity/Q103983010">
+      <rdfs:subClassOf rdf:resource="http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C17564"/>
+      <rdfs:label xml:lang="en">Test No. 490: In Vitro Mammalian Cell Gene Mutation Tests Using the Thymidine Kinase Gene</rdfs:label>
+    </owl:Class>
     
     <!-- http://www.wikidata.org/entity/Q57975142 -->
 


### PR DESCRIPTION
Added Test No. 490: In Vitro Mammalian Cell Gene Mutation Tests Using the Thymidine Kinase Gene (https://www.wikidata.org/wiki/Q103983010) to Wikidata.owl file to include this test as a subclass of Guideline (http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C17564).