### PR TITLE
Integrated 'digestive gland' into the ENM hierarchy

### DIFF
--- a/config/uberon.iris
+++ b/config/uberon.iris
@@ -1,1 +1,4 @@
-+(http://purl.obolibrary.org/obo/UBERON_0002368;http://purl.obolibrary.org/obo/UBERON_0013765):http://purl.obolibrary.org/obo/UBERON_0006925 digestive system gland;digestive gland
++(http://purl.obolibrary.org/obo/BFO_0000001):http://purl.obolibrary.org/obo/UBERON_0001062 anatomical entity
+*(http://purl.obolibrary.org/obo/UBERON_0001062):http://purl.obolibrary.org/obo/UBERON_0000062 organ
++(http://purl.obolibrary.org/obo/UBERON_0000062):http://purl.obolibrary.org/obo/UBERON_0002530 gland
++(http://purl.obolibrary.org/obo/UBERON_0002530):http://purl.obolibrary.org/obo/UBERON_0006925 digestive system gland;digestive gland


### PR DESCRIPTION
@laurent2207, I opted for starting from `anatomical entity` which is positioned at the same level as `material entity`. This does introduce a fifth "top" level entity, but otherwise we would have to add `independent continuant` from BFO, which we in eNanoMapper tried to hide (and thus not have in the ontology).