### PR TITLE
Added missing acknowledgements and bumped the version number

### DIFF
--- a/enanomapper.owl
+++ b/enanomapper.owl
@@ -53,9 +53,11 @@
         <owl:imports rdf:resource="http://enanomapper.github.io/ontologies/internal/pato-ext.owl"/>
         <owl:imports rdf:resource="http://enanomapper.github.io/ontologies/internal/wikidata.owl"/>
         <owl:imports rdf:resource="http://enanomapper.github.io/ontologies//enanomapper-auto.owl"/>
-        <owl:versionInfo>7.0</owl:versionInfo>
+        <owl:versionInfo>7.1</owl:versionInfo>
         <dc:contributor>The eNanoMapper Consortium</dc:contributor>
         <dc:contributor>The NanoCommons Consortium</dc:contributor>
+        <dc:contributor>The ACEnano - Analytical and Characterisation Excellence in nanomaterial risk assessment: A tiered approach (Grant Agreement 720952) Consortium</dc:contributor>
+        <dc:contributor>NanoinformaTIX - Development and Implementation of a Sustainable Modelling Platform for NanoInformatics (Grant Agreement 814426) Consortium</dc:contributor>
         <rdfs:comment>The eNanoMapper project (https://www.enanomapper.net/) and NanoCommons project (https://www.nanocommons.eu/) are creating a pan-European computational infrastructure for toxicological data management for ENMs, based on semantic web standards and ontologies. This ontology is an application ontology targeting the full domain of nanomaterial safety assessment. It re-uses several other ontologies including the NPO, CHEMINF, ChEBI, and ENVO. </rdfs:comment>
         <dc:contributor>Nina Jeliazkova</dc:contributor>
         <dc:contributor>Janna Hastings</dc:contributor>
@@ -70,6 +72,7 @@
         <dc:contributor>Oana Florean</dc:contributor>
         <dc:contributor>Denise Slenter</dc:contributor>
 	<dc:contributor>Laurent Winckers</dc:contributor>
+	<dc:contributor>Ali Ayadi</dc:contributor>
     </owl:Ontology>
 </rdf:RDF>
 


### PR DESCRIPTION
Laurent, when looking into cleanup up in the `internal` folder content, I noted two things that warrant a small update release:

* new acknowledgements did not get copied
* four files in `internal/` were not well-formed

The second is bad, and I am surprised we did not notice that in Protege. That was fixed in https://github.com/enanomapper/ontologies/commit/baf55094c45e0da47cb76fd356b15b29d3aafb82 already applied in `master`.

All in all, enough to make a minor (7.1) release. If you agree, please merge in this pull request, add whatever additional things you like to add, and then make a formal release.