### PR TITLE
Added six more JRC materials

### DIFF
--- a/internal/npo-ext.owl
+++ b/internal/npo-ext.owl
@@ -3112,6 +3112,60 @@
         <synonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NRCWE-006</synonym>
     </owl:Class>
 
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000259 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000259">
+        <rdfs:subClassOf rdf:resource="http://purl.bioontology.org/ontology/npo#NPO_1892"/>
+        <obo:IAO_0000115>A silver nanoparticle from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM03001a</rdfs:label>
+    </owl:Class>
+
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000260 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000260">
+        <rdfs:subClassOf rdf:resource="http://purl.bioontology.org/ontology/npo#NPO_1892"/>
+        <obo:IAO_0000115>A silver nanoparticle from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM03002a</rdfs:label>
+    </owl:Class>
+
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000261 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000261">
+        <rdfs:subClassOf rdf:resource="http://purl.bioontology.org/ontology/npo#NPO_354"/>
+        <obo:IAO_0000115>A multiwall carbon nanotube from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM04002a</rdfs:label>
+    </owl:Class>
+
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000262 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000262">
+        <rdfs:subClassOf rdf:resource="http://purl.bioontology.org/ontology/npo#NPO_354"/>
+        <obo:IAO_0000115>A multiwall carbon nanotube from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM04003a</rdfs:label>
+    </owl:Class>
+
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000263 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000263">
+        <rdfs:subClassOf rdf:resource="http://purl.bioontology.org/ontology/npo#NPO_943"/>
+        <obo:IAO_0000115>A singlewall carbon nanotube from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM46000a</rdfs:label>
+    </owl:Class>
+
+
+    <!-- http://purl.enanomapper.org/onto/ENM_9000264 -->
+
+    <owl:Class rdf:about="http://purl.enanomapper.org/onto/ENM_9000264">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_134404"/>
+        <obo:IAO_0000115>A graphene nanoparticle from the JRC library.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">JRCNM48001a</rdfs:label>
+    </owl:Class>
+
 </rdf:RDF>
 
 


### PR DESCRIPTION
Please double check the ENM identifiers are indeed not used yet.

For https://nanocommons.github.io/specifications/jrc/