### PR TITLE
Added msio config files for Lethal Dose term, solves #347

### DIFF
--- a/config/msio.iris
+++ b/config/msio.iris
@@ -1,0 +1,1 @@
+    +(http://www.bioassayontology.org/bao#BAO_0002116):http://purl.obolibrary.org/obo/MSIO_0000175 Lethal dose (no specific %)

--- a/config/msio.props
+++ b/config/msio.props
@@ -1,0 +1,3 @@
+owl=https://raw.githubusercontent.com/ISA-tools/MSIO/master/MSIO-edit.owl
+iris=msio.iris
+slimmed=http://purl.enanomapper.net/onto/external/msio-slim.owl


### PR DESCRIPTION
Adding Lethal Dose (a dosage endpoint which is lethal at some %) under dosage endpoint.

@egonw assigning you because this term (one of Ammar's requests for the NanoCommons RDF) is in a new upstream ontology, [MSIO](https://github.com/ISA-tools/MSIO), what are your thoughts? 

Also,this is the last term in the list #336 