### PR TITLE
Fixes issue with punning that made the ontology non-DL

### DIFF
--- a/config/aopo.iris
+++ b/config/aopo.iris
@@ -3,4 +3,4 @@
 +(http://aopkb.org/aop_ontology#AopEntity):http://aopkb.org/aop_ontology#AdverseOutcome AO
 +(http://aopkb.org/aop_ontology#AopEntity):http://aopkb.org/aop_ontology#KeyEvent AO
 +(http://aopkb.org/aop_ontology#AopEntity):http://aopkb.org/aop_ontology#MolecularInitiatingEvent MIE
-
+-:http://purl.org/spar/cito/citesAsAuthority

--- a/config/clo.iris
+++ b/config/clo.iris
@@ -4,3 +4,4 @@
 +(http://purl.obolibrary.org/obo/CL_0000003):http://purl.obolibrary.org/obo/CL_1001603 lung macrophage
 +(http://purl.obolibrary.org/obo/CL_0000000):http://purl.obolibrary.org/obo/CL_0001034 cell in vitro
 +(http://purl.obolibrary.org/obo/CL_0001034):http://purl.obolibrary.org/obo/CL_0000010 cultured cell (including cell lines)
+-:http://purl.org/spar/cito/citesAsAuthority

--- a/config/pato.iris
+++ b/config/pato.iris
@@ -19,3 +19,4 @@
 +(http://purl.obolibrary.org/obo/PATO_0000068):http://purl.obolibrary.org/obo/PATO_0002632 secondary
 +(http://purl.obolibrary.org/obo/BFO_0000019):http://purl.obolibrary.org/obo/PATO_0000150 texture
 +(http://purl.obolibrary.org/obo/PATO_0000150):http://purl.obolibrary.org/obo/PATO_0002012 coating
+-:http://purl.org/spar/cito/citesAsAuthority

--- a/config/uberon.iris
+++ b/config/uberon.iris
@@ -3,3 +3,4 @@
 +(http://purl.obolibrary.org/obo/UBERON_0000062):http://purl.obolibrary.org/obo/UBERON_0002530 gland
 +(http://purl.obolibrary.org/obo/UBERON_0002530):http://purl.obolibrary.org/obo/UBERON_0006925 digestive system gland;digestive gland
 +(http://purl.obolibrary.org/obo/UBERON_0001062):http://purl.obolibrary.org/obo/UBERON_0000479 tissue
+-:http://purl.org/spar/cito/citesAsAuthority

--- a/scripts/src/tests/test_owl_integrity.py
+++ b/scripts/src/tests/test_owl_integrity.py
@@ -29,7 +29,16 @@ class OWLIntegrityTest(unittest.TestCase):
         for version in config['versions']:
             file = os.path.join(self.repo_path, f'enanomapper{version}.owl')
             self.assertTrue(self.is_owl_file_valid(file), f"Invalid eNanoMapper ontology OWL file: enanomapper{version}.owl")
-
+        internal = os.listdir('internal')
+        internal_dev = os.listdir('internal-dev')
+        for i in internal:
+            if 'OWL'.casefold() in i:
+                file = os.path.join(self.repo_path, 'internal', i)
+                self.assertTrue(self.is_owl_file_valid(file), f"Invalid eNanoMapper internal module OWL file: {i}")
+        for i in internal_dev:
+            if 'OWL'.casefold() in i:
+                file = os.path.join(self.repo_path, 'internal-dev', i)
+                self.assertTrue(self.is_owl_file_valid(file), f"Invalid eNanoMapper internal-dev module OWL file: {i}")
     def load_configuration(self):
         """Load the configuration from the YAML file and return it as a dictionary."""
         
@@ -44,6 +53,7 @@ class OWLIntegrityTest(unittest.TestCase):
         Returns:
             bool: True if the file is valid, False otherwise.
         """
+        
         try:
             graph = Graph()
             graph.parse(file_path, format='xml')
@@ -51,6 +61,7 @@ class OWLIntegrityTest(unittest.TestCase):
         except Exception as e:
             print(f"Error parsing OWL file: {file_path}\n{e}")
             return False
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Running `robot validate-profile DL` (to assess whether the ontology complies with Description Logic, important if ) locally on a merged `enanomapper-full.owl` returned a punning error where cito:citesdAsAuthority was both an AnnotationProperty and an ObjectProperty. The config changes removes the imported properties that conflicted with the source CiTO ontology.