### PR TITLE
Fixes bioassay specification

### DIFF
--- a/config/bao.iris
+++ b/config/bao.iris
@@ -5,7 +5,6 @@
 +D(http://purl.obolibrary.org/obo/OBI_0000070):http://www.bioassayontology.org/bao#BAO_0000015 bioassay
 +:http://www.bioassayontology.org/bao#BAO_0000338 has concentration
 +:http://www.bioassayontology.org/bao#BAO_0000208 has endpoint
-+D(http://purl.obolibrary.org/obo/IAO_0000030):http://www.bioassayontology.org/bao#BAO_0000520 assay description
 -D:http://www.bioassayontology.org/bao#BAO_0002135 solubility
 +D:(http://purl.enanomapper.org/onto/ENM_0000035):http://www.bioassayontology.org/bao#BAO_0002128 physical property endpoint
 -D:http://www.bioassayontology.org/bao#BAO_0002805 Cell proliferation assay
@@ -14,7 +13,6 @@
 +D(http://www.bioassayontology.org/bao#BAO_0000625):http://www.bioassayontology.org/bao#BAO_0000435 Hill equation
 +(http://purl.obolibrary.org/obo/OBI_0000070):http://www.bioassayontology.org/bao#BAO_0000428 isothermal titration calorimetry
 +(http://purl.bioontology.org/ontology/npo#NPO_1436):http://www.bioassayontology.org/bao#BAO_0000578 cuvette
-+(http://www.bioassayontology.org/bao#BAO_0000015):http://www.bioassayontology.org/bao#BAO_0000026 bioassay specification
-+(http://www.bioassayontology.org/bao#BAO_0000026):http://www.bioassayontology.org/bao#BAO_0000008 bioassay type
++D(http://purl.obolibrary.org/obo/IAO_0000030):http://www.bioassayontology.org/bao#BAO_0000026 bioassay specification
 +(http://www.bioassayontology.org/bao#BAO_0000008):http://www.bioassayontology.org/bao#BAO_0002810 physicochemical
 +(http://purl.bioontology.org/ontology/npo#NPO_1420):http://www.bioassayontology.org/bao#BAO_0010019 PAGE

--- a/external-dev/aopo-slim.owl
+++ b/external-dev/aopo-slim.owl
@@ -44,15 +44,15 @@
         <terms:license rdf:resource="https://hpo.jax.org/app/license"/>
         <pav:importedFrom>https://raw.githubusercontent.com/jmillanacosta/aop-ontology/patch-1/aopo.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:22:22</oboInOwl:date>
-        <oboInOwl:date>27:07:2023 19:35</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:51:37</oboInOwl:date>
+        <oboInOwl:date>27:08:2023 19:12</oboInOwl:date>
         <oboInOwl:default-namespace>chebi_ontology</oboInOwl:default-namespace>
         <oboInOwl:default-namespace>human_phenotype</oboInOwl:default-namespace>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <oboInOwl:logical-definition-view-relation>has_part</oboInOwl:logical-definition-view-relation>
         <oboInOwl:saved-by>chebi</oboInOwl:saved-by>
         <rdfs:comment>Author: ChEBI curation team</rdfs:comment>
-        <rdfs:comment>ChEBI Release version 224</rdfs:comment>
+        <rdfs:comment>ChEBI Release version 225</rdfs:comment>
         <rdfs:comment>ChEBI subsumes and replaces the Chemical Ontology first</rdfs:comment>
         <rdfs:comment>Contact:
 Stephan Schurer
@@ -96,7 +96,7 @@ Uma Vempati, Hande Küçük, Ubbo Visser, Saminda Abeyruwan, Kunie Sakurai, Vanc
         <owl:versionInfo>2.8.4</owl:versionInfo>
         <owl:versionInfo>2.8.6</owl:versionInfo>
         <owl:versionInfo>2.8.7</owl:versionInfo>
-        <owl:versionInfo>2023-06-17</owl:versionInfo>
+        <owl:versionInfo>2023-09-01</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>
     </owl:Ontology>
     

--- a/external-dev/bao-slim.owl
+++ b/external-dev/bao-slim.owl
@@ -24,7 +24,7 @@
         <dc:license rdf:resource="https://creativecommons.org/licenses/by-sa/4.0/"/>
         <pav:importedFrom>http://bioassayontology.org/bao/bao_complete_merged.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:22:29</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:51:45</oboInOwl:date>
         <rdfs:comment>Contact:
 Stephan Schurer
 stephan dot schurer at gmail dot com</rdfs:comment>

--- a/external-dev/bfo-slim.owl
+++ b/external-dev/bfo-slim.owl
@@ -45,7 +45,7 @@
         <dc:license rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/bfo/classes-only.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:22:32</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:51:48</oboInOwl:date>
         <rdfs:comment xml:lang="en">The http://purl.obolibary.org/obo/bfo/classes-only.owl variant of BFO (&quot;bfo_classes_only.owl&quot;) includes only the class hierarchy and annotations from the full OWL version of BFO 2: http://purl.obolibary.org/obo/bfo.owl (&quot;bfo.owl&quot;). There are no object properties or logical axioms that use the object properties in bfo_classes_only.owl. As the logical axioms in the bfo_classes_only.owl variant are limited to subclass and disjoint assertions they are much weaker than the logical axioms in bfo.owl.
  
 If you plan to use the relations that define BFO 2, you should import bfo.owl instead of bfo_classes_only.owl. To the extent that the relations are used without importing bfo.owl, be mindful that they should be used in a manner consistent with their use in bfo.owl. Otherwise if your ontology is imported by a another ontology that imports bfo.owl there may be inconsistencies. 

--- a/external-dev/ccont-slim.owl
+++ b/external-dev/ccont-slim.owl
@@ -15,7 +15,7 @@
         <pav:importedFrom>https://raw.githubusercontent.com/enanomapper/ontologies/master/internal/ccont-ext.owl</pav:importedFrom>
         <efo:creator>Matthias Ganzinger, matthias.ganzinger@med.uni-heidelberg.de</efo:creator>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:22:40</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:52:23</oboInOwl:date>
         <rdfs:label>cell culture ontology (CCONT)</rdfs:label>
         <owl:versionInfo>1.1</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/chebi-slim.owl
+++ b/external-dev/chebi-slim.owl
@@ -17,13 +17,13 @@
     <owl:Ontology rdf:about="http://purl.enanomapper.net/onto/external/chebi-slim.owl">
         <pav:importedFrom>http://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi_lite.obo</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:23:40</oboInOwl:date>
-        <oboInOwl:date>27:07:2023 19:35</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:53:28</oboInOwl:date>
+        <oboInOwl:date>27:08:2023 19:12</oboInOwl:date>
         <oboInOwl:default-namespace>chebi_ontology</oboInOwl:default-namespace>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <oboInOwl:saved-by>chebi</oboInOwl:saved-by>
         <rdfs:comment>Author: ChEBI curation team</rdfs:comment>
-        <rdfs:comment>ChEBI Release version 224</rdfs:comment>
+        <rdfs:comment>ChEBI Release version 225</rdfs:comment>
         <rdfs:comment>ChEBI subsumes and replaces the Chemical Ontology first</rdfs:comment>
         <rdfs:comment>For any queries contact chebi-help@ebi.ac.uk</rdfs:comment>
         <rdfs:comment>developed by Michael Ashburner &amp; Pankaj Jaiswal.</rdfs:comment>

--- a/external-dev/cheminf-slim.owl
+++ b/external-dev/cheminf-slim.owl
@@ -79,7 +79,7 @@
         <terms:license>http://creativecommons.org/publicdomain/zero/1.0/</terms:license>
         <pav:importedFrom>http://semanticchemistry.github.io/semanticchemistry/ontology/cheminf.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:22:45</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:52:28</oboInOwl:date>
         <rdfs:comment xml:lang="en">An information artifact is, loosely, a dependent continuant or its bearer that is created as the result of one or more intentional processes. Examples: uniprot, the english language, the contents of this document or a printout of it, the temperature measurements from a weather balloon. For more information, see the project home page at https://github.com/information-artifact-ontology/IAO</rdfs:comment>
         <rdfs:comment>Document containing upporting external terms</rdfs:comment>
         <rdfs:comment>IDs allocated to related efforts: PNO: IAO_0020000-IAO_0020999, D_ACTS: IAO_0021000-IAO_0021999</rdfs:comment>

--- a/external-dev/chmo-slim.owl
+++ b/external-dev/chmo-slim.owl
@@ -19,7 +19,7 @@
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/chmo.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:23:47</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:53:35</oboInOwl:date>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <oboInOwl:saved-by>batchelorc</oboInOwl:saved-by>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/clo-slim.owl
+++ b/external-dev/clo-slim.owl
@@ -46,7 +46,7 @@
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/cl.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:24:07</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:53:54</oboInOwl:date>
         <rdfs:comment>See PMID:15693950, PMID:12799354, PMID:20123131, PMID:21208450; Contact Alexander Diehl, addiehl@buffalo.edu, University at Buffalo.</rdfs:comment>
         <owl:versionInfo>2023-08-24</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/envo-slim.owl
+++ b/external-dev/envo-slim.owl
@@ -35,7 +35,7 @@
         <doap:GitRepository rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/EnvironmentOntology/envo/</doap:GitRepository>
         <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/EnvironmentOntology/envo/issues/</doap:bug-database>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:25:41</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:55:25</oboInOwl:date>
         <oboInOwl:default-namespace>ENVO</oboInOwl:default-namespace>
         <rdfs:comment>Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/chemical_concentration.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 679 Logical Axioms: 119]</rdfs:comment>
         <rdfs:comment>Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/envo/modules/entity_attribute.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 206 Logical Axioms: 34]</rdfs:comment>

--- a/external-dev/fabio-slim.owl
+++ b/external-dev/fabio-slim.owl
@@ -33,7 +33,7 @@ FaBiO classes are structured according to the FRBR schema of Works, Expressions,
         <vann:preferredNamespacePrefix>fabio</vann:preferredNamespacePrefix>
         <vann:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.org/spar/fabio/</vann:preferredNamespaceUri>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:25:46</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:55:31</oboInOwl:date>
         <rdfs:comment>FaBiO, the FRBR-aligned Bibliographic Ontology, is an ontology for recording and publishing on the Semantic Web bibliographic records of scholarly endeavours. It forms part of SPAR, a suite of Semantic Publishing and Referencing Ontologies.  Other SPAR ontologies are described at http://purl.org/spar/.
 
 This ontology is available at http://purl.org/spar/fabio, and uses the namespace prefix fabio.</rdfs:comment>

--- a/external-dev/go-slim.owl
+++ b/external-dev/go-slim.owl
@@ -24,7 +24,7 @@
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/go.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:26:22</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:56:10</oboInOwl:date>
         <oboInOwl:default-namespace>gene_ontology</oboInOwl:default-namespace>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <owl:versionInfo>2023-07-27</owl:versionInfo>

--- a/external-dev/iao-slim.owl
+++ b/external-dev/iao-slim.owl
@@ -57,7 +57,7 @@
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/iao.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:26:25</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:56:13</oboInOwl:date>
         <rdfs:comment xml:lang="en">An information artifact is, loosely, a dependent continuant or its bearer that is created as the result of one or more intentional processes. Examples: uniprot, the english language, the contents of this document or a printout of it, the temperature measurements from a weather balloon. For more information, see the project home page at https://github.com/information-artifact-ontology/IAO</rdfs:comment>
         <rdfs:comment>IDs allocated to related efforts: PNO: IAO_0020000-IAO_0020999, D_ACTS: IAO_0021000-IAO_0021999</rdfs:comment>
         <rdfs:comment>IDs allocated to subdomains of IAO. pno.owl: IAO_0020000-IAO_0020999, d-acts.owl: IAO_0021000-IAO_0021999</rdfs:comment>

--- a/external-dev/msio-slim.owl
+++ b/external-dev/msio-slim.owl
@@ -181,7 +181,7 @@ http://www.cosmos-fp7.eu/WP2</doap:maintainer>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
         <oboInOwl:created_by xml:lang="en">Daniel Schober</oboInOwl:created_by>
         <oboInOwl:creation_date xml:lang="en">2017-10-19T10:11:26Z</oboInOwl:creation_date>
-        <oboInOwl:date>2023-09-01 01:31:12</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:01:13</oboInOwl:date>
         <rdfs:comment xml:lang="en">Please see the project site https://github.com/BFO-ontology/BFO, the bfo2 owl discussion group http://groups.google.com/group/bfo-owl-devel, the bfo2 discussion group http://groups.google.com/group/bfo-devel, the tracking google doc http://goo.gl/IlrEE, and the current version of the bfo2 reference http://purl.obolibrary.org/obo/bfo/dev/bfo2-reference.docx. This ontology is generated from a specification at https://github.com/BFO-ontology/BFO/tree/master/src/ontology/owl-group/specification/ and with the code that generates the OWL version in https://github.com/BFO-ontology/BFO/tree/master/src/tools/. A very early version of BFO version 2 in CLIF is at http://purl.obolibrary.org/obo/bfo/dev/bfo.clif.</rdfs:comment>
         <rdfs:comment xml:lang="en">The BSD license on the BFO project site refers to code used to build BFO.</rdfs:comment>
         <rdfs:comment xml:lang="en">This version (1.1.0) uses the Basic Formal Ontology (BFO) as its top level ontology.  We might at some point close the resulting semantic gap by using OBI and IAO as intermediate bridges.</rdfs:comment>

--- a/external-dev/ncit-slim.owl
+++ b/external-dev/ncit-slim.owl
@@ -21,7 +21,7 @@
         <terms:title>NCI Thesaurus OBO Edition</terms:title>
         <pav:importedFrom>http://purl.obolibrary.org/obo/ncit.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:29:45</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:59:35</oboInOwl:date>
         <rdfs:comment>NCI Thesaurus, a controlled vocabulary in support of NCI administrative and scientific activities. Produced by the Enterprise Vocabulary System (EVS), a project by the NCI Center for Biomedical Informatics and Information Technology. National Cancer Institute, National Institutes of Health, Bethesda, MD 20892, U.S.A.</rdfs:comment>
         <owl:versionInfo>22.07d</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/npo-slim.owl
+++ b/external-dev/npo-slim.owl
@@ -17,7 +17,7 @@
         <dc:identifier>http://purl.bioontology.org/ontology/npo</dc:identifier>
         <pav:importedFrom>https://raw.githubusercontent.com/enanomapper/npo/master/npo-inferred.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:29:51</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 09:59:40</oboInOwl:date>
         <rdfs:comment>Inferred version created with Pellet reasoner in Protege editor (v. 4.1)</rdfs:comment>
         <rdfs:comment>The NPO was primarily developed by Dennis G. Thomas in collaboration with Nathan A. Baker and Rohit V. Pappu. This development was supported by the NIH through grants U54 CA119342 and U54 HG004028.</rdfs:comment>
         <owl:versionInfo>2013-05-31 (yyyy-mm-dd)</owl:versionInfo>

--- a/external-dev/obcs-slim.owl
+++ b/external-dev/obcs-slim.owl
@@ -27,7 +27,7 @@
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/obcs.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:30:11</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:00:00</oboInOwl:date>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">101</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>
     </owl:Ontology>

--- a/external-dev/obi-slim.owl
+++ b/external-dev/obi-slim.owl
@@ -82,7 +82,7 @@
         <terms:title>Ontology for Biomedical Investigations</terms:title>
         <pav:importedFrom>http://purl.obolibrary.org/obo/obi.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:30:18</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:00:08</oboInOwl:date>
         <rdfs:comment>Please cite the OBI consortium http://purl.obolibrary.org/obo/obi where traditional citation is called for. However it is adequate that individual terms be attributed simply by use of the identifying PURL for the term, in projects that refer to them.</rdfs:comment>
         <owl:versionInfo>2023-07-25</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/pato-slim.owl
+++ b/external-dev/pato-slim.owl
@@ -39,7 +39,7 @@
         <terms:license rdf:resource="https://creativecommons.org/licenses/by/3.0/"/>
         <pav:importedFrom>http://purl.obolibrary.org/obo/pato.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:30:32</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:00:27</oboInOwl:date>
         <oboInOwl:default-namespace>quality</oboInOwl:default-namespace>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <owl:versionInfo>2023-05-18</owl:versionInfo>

--- a/external-dev/sio-slim.owl
+++ b/external-dev/sio-slim.owl
@@ -80,7 +80,7 @@ mailing list: http://groups.google.com/group/sio-ontology
 role chains:
 &apos;has capability&apos; o &apos;is realized in&apos; -&gt; &apos;is participant in&apos;</schema:comment>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:30:35</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:00:31</oboInOwl:date>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://sio.semanticscience.org</rdfs:seeAlso>
         <owl:versionInfo>1.59</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>

--- a/external-dev/uberon-slim.owl
+++ b/external-dev/uberon-slim.owl
@@ -24,7 +24,6 @@
      xmlns:ncicp="http://ncicb.nci.nih.gov/xml/owl/EVS/ComplexProperties.xsd#"
      xmlns:swrla="http://swrl.stanford.edu/ontologies/3.3/swrla.owl#"
      xmlns:terms="http://purl.org/dc/terms/"
-     xmlns:vocab="https://w3id.org/semapv/vocab/"
      xmlns:chebi2="http://purl.obolibrary.org/obo/chebi#"
      xmlns:chebi3="http://purl.obolibrary.org/obo/chebi#1"
      xmlns:chebi4="http://purl.obolibrary.org/obo/chebi#3"
@@ -159,7 +158,7 @@
         <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/obophenotype/uberon/issues/</doap:bug-database>
         <doap:mailing-list rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://lists.sourceforge.net/lists/listinfo/obo-anatomy</doap:mailing-list>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:31:03</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:01:00</oboInOwl:date>
         <oboInOwl:default-namespace>uberon</oboInOwl:default-namespace>
         <oboInOwl:hasOBOFormatVersion>1.2</oboInOwl:hasOBOFormatVersion>
         <oboInOwl:treat-xrefs-as-equivalent>AEO</oboInOwl:treat-xrefs-as-equivalent>
@@ -201,8 +200,6 @@
         <oboInOwl:treat-xrefs-as-reverse-genus-differentia>ZFA part_of NCBITaxon:7954</oboInOwl:treat-xrefs-as-reverse-genus-differentia>
         <oboInOwl:treat-xrefs-as-reverse-genus-differentia>ZFS part_of NCBITaxon:7954</oboInOwl:treat-xrefs-as-reverse-genus-differentia>
         <rdfs:comment>Aurelie Comte, Bill Bug, Catherine Leroy, Duncan Davidson and Trish Whetzel are also contributors. However their ORCIDs were not found.</rdfs:comment>
-        <rdfs:comment>Includes Ontology(OntologyID(OntologyIRI(&lt;http://purl.obolibrary.org/obo/uberon-bridge-to-bfo.owl&gt;) VersionIRI(&lt;null&gt;))) [Axioms: 20 Logical Axioms: 9]</rdfs:comment>
-        <owl:versionInfo>2023-07-25</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>
         <foaf:homepage rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://uberon.org</foaf:homepage>
     </owl:Ontology>
@@ -253,11 +250,6 @@
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
-        <obo:IAO_0000111 xml:lang="en">example of usage</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
         <oboInOwl:hasDbXref>IAO:0000112</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:id>example_of_usage</oboInOwl:id>
@@ -281,31 +273,6 @@
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
-        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">2012-04-05: 
-Barry Smith
-
-The official OBI definition, explaining the meaning of a class or property: &apos;Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions&apos;  is terrible.
-
-Can you fix to something like:
-
-A statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.
-
-Alan Ruttenberg
-
-Your proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can&apos;t be evaluated by those criteria. 
-
-On the specifics of the proposed definition:
-
-We don&apos;t have definitions of &apos;meaning&apos; or &apos;expression&apos; or &apos;property&apos;. For &apos;reference&apos; in the intended sense I think we use the term &apos;denotation&apos;. For &apos;expression&apos;, I think we you mean symbol, or identifier. For &apos;meaning&apos; it differs for class and property. For class we want documentation that let&apos;s the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let&apos;s the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The &apos;intended reader&apos; part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. 
-
-Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
-
-We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  </obo:IAO_0000116>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
         <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
         <rdfs:label xml:lang="en">definition</rdfs:label>
         <rdfs:label>definition</rdfs:label>
@@ -317,11 +284,6 @@ We also have the outstanding issue of how to aim different definitions to differ
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
-        <obo:IAO_0000111 xml:lang="en">editor note</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obofoundry.org/obo/obi&gt;</obo:IAO_0000119>
         <oboInOwl:hasDbXref>IAO:0000116</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:id>editor_note</oboInOwl:id>
@@ -358,13 +320,7 @@ We also have the outstanding issue of how to aim different definitions to differ
     <!-- http://purl.obolibrary.org/obo/IAO_0000231 -->
 
 
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231">
-        <obo:IAO_0000111 xml:lang="en">has obsolescence reason</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">has obsolescence reason</rdfs:label>
-    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231"/>
     
 
 
@@ -372,10 +328,6 @@ We also have the outstanding issue of how to aim different definitions to differ
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
-        <obo:IAO_0000111 xml:lang="en">curator note</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
-        <obo:IAO_0000115 xml:lang="en">An administrative note of use for a curator but of no use for a user</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
         <oboInOwl:hasDbXref>IAO:0000232</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:id>curator_notes</oboInOwl:id>
@@ -393,12 +345,6 @@ We also have the outstanding issue of how to aim different definitions to differ
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233">
-        <obo:IAO_0000111 xml:lang="en">term tracker item</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/</obo:IAO_0000112>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">An IRI or similar locator for a request or discussion of an ontology term.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000119>
         <oboInOwl:hasDbXref>IAO:0000233</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace>external</oboInOwl:hasOBONamespace>
         <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
@@ -406,8 +352,6 @@ We also have the outstanding issue of how to aim different definitions to differ
         <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
         <oboInOwl:is_metadata_tag rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_metadata_tag>
         <oboInOwl:shorthand>term_tracker_item</oboInOwl:shorthand>
-        <rdfs:comment xml:lang="en">The &apos;tracker item&apos; can associate a tracker with a specific ontology term.</rdfs:comment>
-        <rdfs:label xml:lang="en">term tracker item</rdfs:label>
         <rdfs:label>term tracker item</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -424,14 +368,6 @@ We also have the outstanding issue of how to aim different definitions to differ
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000425">
-        <obo:IAO_0000111 xml:lang="en">expand assertion to</obo:IAO_0000111>
-        <obo:IAO_0000112 xml:lang="en">ObjectProperty: RO???
-Label: spatially disjoint from
-Annotations: expand_assertion_to &quot;DisjointClasses: (http://purl.obolibrary.org/obo/BFO_0000051 some ?X)  (http://purl.obolibrary.org/obo/BFO_0000051 some ?Y)&quot;
-</obo:IAO_0000112>
-        <obo:IAO_0000115 xml:lang="en">A macro expansion tag applied to an annotation property which can be expanded into a more detailed axiom.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Chris Mungall</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">expand assertion to</rdfs:label>
         <rdfs:label>expand assertion to</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -497,13 +433,6 @@ Annotations: expand_assertion_to &quot;DisjointClasses: (http://purl.obolibrary.
 
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
-        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
-        <rdfs:comment xml:lang="en">Add as annotation triples in the granting ontology</rdfs:comment>
-        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
         <rdfs:label>term replaced by</rdfs:label>
     </owl:AnnotationProperty>
     
@@ -2614,13 +2543,6 @@ WHERE {
     
 
 
-    <!-- http://purl.org/dc/terms/description -->
-
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/description"/>
-    
-
-
     <!-- http://purl.org/dc/terms/isReferencedBy -->
 
 
@@ -2639,13 +2561,6 @@ WHERE {
 
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/source"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/title -->
-
-
-    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
     
 
 
@@ -2955,12 +2870,7 @@ WHERE {
 
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym">
-        <obo:IAO_0000115>An alternative label for a class or property which has a more general meaning than the preferred name/primary label.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
-        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/18</obo:IAO_0000233>
-        <rdfs:label xml:lang="en">has broad synonym</rdfs:label>
         <rdfs:label>has_broad_synonym</rdfs:label>
-        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/18</rdfs:seeAlso>
     </owl:AnnotationProperty>
     
 
@@ -2978,12 +2888,7 @@ WHERE {
 
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
-        <obo:IAO_0000115>An alternative label for a class or property which has the exact same meaning than the preferred name/primary label.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
-        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/20</obo:IAO_0000233>
-        <rdfs:label xml:lang="en">has exact synonym</rdfs:label>
         <rdfs:label>has_exact_synonym</rdfs:label>
-        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/20</rdfs:seeAlso>
     </owl:AnnotationProperty>
     
 
@@ -2992,12 +2897,7 @@ WHERE {
 
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym">
-        <obo:IAO_0000115>An alternative label for a class or property which has a more specific meaning than the preferred name/primary label.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
-        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/19</obo:IAO_0000233>
-        <rdfs:label xml:lang="en">has narrow synonym</rdfs:label>
         <rdfs:label>has_narrow_synonym</rdfs:label>
-        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/19</rdfs:seeAlso>
     </owl:AnnotationProperty>
     
 
@@ -3022,12 +2922,7 @@ WHERE {
 
 
     <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
-        <obo:IAO_0000115>An alternative label for a class or property that has been used synonymously with the primary term name, but the usage is not strictly correct.</obo:IAO_0000115>
-        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
-        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/21</obo:IAO_0000233>
-        <rdfs:label xml:lang="en">has related synonym</rdfs:label>
         <rdfs:label>has_related_synonym</rdfs:label>
-        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/21</rdfs:seeAlso>
     </owl:AnnotationProperty>
     
 
@@ -3475,13 +3370,6 @@ WHERE {
     
 
 
-    <!-- https://w3id.org/semapv/vocab/crossSpeciesExactMatch -->
-
-
-    <owl:AnnotationProperty rdf:about="https://w3id.org/semapv/vocab/crossSpeciesExactMatch"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -3857,123 +3745,6 @@ WHERE {
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
-    // Individuals
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000002 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000002">
-        <obo:IAO_0000111 xml:lang="en">example to be eventually removed</obo:IAO_0000111>
-        <rdfs:label xml:lang="en">example to be eventually removed</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000120 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000120">
-        <obo:IAO_0000111 xml:lang="en">metadata complete</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">metadata complete</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000121 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000121">
-        <obo:IAO_0000111 xml:lang="en">organizational term</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Term created to ease viewing/sort terms for development purpose, and will not be included in a release</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">organizational term</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000122 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000122">
-        <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking &quot;ready_for_release&quot; should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed &quot;ready_for_release&quot; will also derived from a chain of ancestor classes that are also &quot;ready_for_release.&quot;</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">ready for release</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000123 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000123">
-        <obo:IAO_0000111 xml:lang="en">metadata incomplete</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">metadata incomplete</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000124 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000124">
-        <obo:IAO_0000111 xml:lang="en">uncurated</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Nothing done yet beyond assigning a unique class ID and proposing a preferred term.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">uncurated</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000125 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000125">
-        <obo:IAO_0000111 xml:lang="en">pending final vetting</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">pending final vetting</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000423 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000423">
-        <obo:IAO_0000111 xml:lang="en">to be replaced with external ontology term</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Terms with this status should eventually replaced with a term from another ontology.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">to be replaced with external ontology term</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000428 -->
-
-
-    <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IAO_0000428">
-        <obo:IAO_0000111 xml:lang="en">requires discussion</obo:IAO_0000111>
-        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
-        <obo:IAO_0000115 xml:lang="en">A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">requires discussion</rdfs:label>
-    </owl:NamedIndividual>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
     // Annotations
     //
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -3981,15 +3752,13 @@ WHERE {
 
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000700">
-        <obo:IAO_0000111 xml:lang="en">has ontology root term</obo:IAO_0000111>
-        <obo:IAO_0000115 xml:lang="en">Ontology annotation property. Relates an ontology to a term that is a designated root term of the ontology. Display tools like OLS can use terms annotated with this property as the starting point for rendering the ontology class hierarchy. There can be more than one root.</obo:IAO_0000115>
-        <obo:IAO_0000117 xml:lang="en">Nicolas Matentzoglu</obo:IAO_0000117>
         <oboInOwl:hasDbXref>IAO:0000700</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace>external</oboInOwl:hasOBONamespace>
         <oboInOwl:hasOBONamespace>uberon</oboInOwl:hasOBONamespace>
         <oboInOwl:id>has_ontology_root_term</oboInOwl:id>
+        <oboInOwl:is_class_level rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_class_level>
         <oboInOwl:is_metadata_tag rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboInOwl:is_metadata_tag>
         <oboInOwl:shorthand>has_ontology_root_term</oboInOwl:shorthand>
-        <rdfs:label xml:lang="en">has ontology root term</rdfs:label>
         <rdfs:label>has ontology root term</rdfs:label>
         <rdfs:label>preferred_root</rdfs:label>
     </rdf:Description>
@@ -4112,86 +3881,6 @@ WHERE {
         <oboInOwl:shorthand>foaf-homepage</oboInOwl:shorthand>
         <rdfs:label>homepage</rdfs:label>
     </rdf:Description>
-    <rdf:Description rdf:about="https://orcid.org/0000-0001-7258-9596">
-        <terms:description>researcher</terms:description>
-        <rdfs:label>Shawn Zheng Kai Tan</rdfs:label>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0001-7258-9596"/>
-        <owl:annotatedProperty rdf:resource="http://purl.org/dc/terms/description"/>
-        <owl:annotatedTarget>researcher</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q57023310"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0001-7258-9596"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>Shawn Zheng Kai Tan</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q57023310"/>
-    </owl:Axiom>
-    <rdf:Description rdf:about="https://orcid.org/0000-0002-2908-3327">
-        <terms:description>data scientist</terms:description>
-        <rdfs:label>Anne Thessen</rdfs:label>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-2908-3327"/>
-        <owl:annotatedProperty rdf:resource="http://purl.org/dc/terms/description"/>
-        <owl:annotatedTarget>data scientist</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q47503085"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-2908-3327"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>Anne Thessen</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q47503085"/>
-    </owl:Axiom>
-    <rdf:Description rdf:about="https://orcid.org/0000-0002-6601-2165">
-        <terms:description>bioinformatics researcher</terms:description>
-        <rdfs:label>Christopher J. Mungall</rdfs:label>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <owl:annotatedProperty rdf:resource="http://purl.org/dc/terms/description"/>
-        <owl:annotatedTarget>bioinformatics researcher</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q20746118"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-6601-2165"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>Christopher J. Mungall</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q20746118"/>
-    </owl:Axiom>
-    <rdf:Description rdf:about="https://orcid.org/0000-0002-7073-9172">
-        <terms:description>researcher</terms:description>
-        <rdfs:label>David Osumi-Sutherland</rdfs:label>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
-        <owl:annotatedProperty rdf:resource="http://purl.org/dc/terms/description"/>
-        <owl:annotatedTarget>researcher</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q54303418"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-7073-9172"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>David Osumi-Sutherland</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q54303418"/>
-    </owl:Axiom>
-    <rdf:Description rdf:about="https://orcid.org/0000-0002-8688-6599">
-        <terms:description>researcher</terms:description>
-        <rdfs:label>James P. Balhoff</rdfs:label>
-    </rdf:Description>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-8688-6599"/>
-        <owl:annotatedProperty rdf:resource="http://purl.org/dc/terms/description"/>
-        <owl:annotatedTarget>researcher</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q37649212"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://orcid.org/0000-0002-8688-6599"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>James P. Balhoff</owl:annotatedTarget>
-        <terms:source rdf:resource="http://www.wikidata.org/entity/Q37649212"/>
-    </owl:Axiom>
 </rdf:RDF>
 
 

--- a/external-dev/uo-slim.owl
+++ b/external-dev/uo-slim.owl
@@ -12,7 +12,7 @@
     <owl:Ontology rdf:about="http://purl.enanomapper.net/onto/external/uo-slim.owl">
         <pav:importedFrom>http://purl.obolibrary.org/obo/uo.owl</pav:importedFrom>
         <oboInOwl:auto-generated-by>Slimmer</oboInOwl:auto-generated-by>
-        <oboInOwl:date>2023-09-01 01:31:06</oboInOwl:date>
+        <oboInOwl:date>2023-09-08 10:01:08</oboInOwl:date>
         <owl:versionInfo>2023-05-25</owl:versionInfo>
         <owl:versionInfo>This SLIM file was generated automatically by the eNanoMapper Slimmer software library. For more information see http://github.com/enanomapper/slimmer.</owl:versionInfo>
     </owl:Ontology>


### PR DESCRIPTION
Imports the whole bioassay specification branch of BAO `http://www.bioassayontology.org/bao#BAO_0000026` under information content entity. 

Extra lines removed are subclasses of bioassay specification which were imported separately under information content entity -not needed anymore.