### PR TITLE
Fix malformed ncit config file

### DIFF
--- a/config/ncit.iris
+++ b/config/ncit.iris
@@ -53,7 +53,7 @@
 +(http://purl.obolibrary.org/obo/UO_0000307):http://purl.obolibrary.org/obo/NCIT_C66976 Miligram per Kilogram per Day
 +(http://purl.obolibrary.org/obo/UO_0000307):http://purl.obolibrary.org/obo/NCIT_C66976 Miligram per Kilogram per Day
 +(http://purl.obolibrary.org/obo/UO_0000180):http://purl.obolibrary.org/obo/NCIT_C42576 Kilogram per Cubic Meter
-+(+(http://purl.obolibrary.org/obo/OBI_0000272):http://purl.obolibrary.org/obo/NCIT_C25572 modification
++(http://purl.obolibrary.org/obo/OBI_0000272):http://purl.obolibrary.org/obo/NCIT_C25572 modification
 +(http://purl.obolibrary.org/obo/UO_0000000):http://purl.obolibrary.org/obo/NCIT_C50400 age unit
 +(http://purl.obolibrary.org/obo/IAO_0000027):http://purl.obolibrary.org/obo/NCIT_C104504 batch number
 +(http://purl.obolibrary.org/obo/OBI_0000070):http://purl.obolibrary.org/obo/NCIT_C119826 exposure method


### PR DESCRIPTION
It led to the tests failing as OBI_0000272 went to the top of the hierarchy due to a typo